### PR TITLE
update warp-contracts dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@three-em/node": "^0.3.22",
     "arweave": "^1.13.5",
     "arweave-mnemonic-keys": "^0.0.9",
-    "warp-contracts": "^1.3.3"
+    "warp-contracts": "1.3.3-beta.3"
   },
   "exports": {
     "./auth": "./dist/lib/auth.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8066,10 +8066,10 @@ warning-symbol@^0.1.0:
   resolved "https://registry.yarnpkg.com/warning-symbol/-/warning-symbol-0.1.0.tgz#bb31dd11b7a0f9d67ab2ed95f457b65825bbad21"
   integrity sha512-1S0lwbHo3kNUKA4VomBAhqn4DPjQkIKSdbOin5K7EFUQNwyIKx+wZMGXKI53RUjla8V2B8ouQduUlgtx8LoSMw==
 
-warp-contracts@^1.3.3:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/warp-contracts/-/warp-contracts-1.3.3.tgz#4dceceb9f86d5e74c2b86208b661c981bdb10e8d"
-  integrity sha512-xxVoM1ETKZXh5TWFRXpRceqKHucyyCf0lwegyDNqx3g/zZXQw9p0Kq7lGSCHWirkVe+Ax+pF/YofDWJ29OVIcw==
+warp-contracts@1.3.3-beta.3:
+  version "1.3.3-beta.3"
+  resolved "https://registry.yarnpkg.com/warp-contracts/-/warp-contracts-1.3.3-beta.3.tgz#a5b3e498c4e546d9fcda2ae8b9b64c413777f0e0"
+  integrity sha512-OM5JXAdE7IqKs73wfARf+kR0m1OVoGP0VyhBh91FSds+UCbtWT2HZAGALNzRhbA/igxkjvE6AVDmr3d2jedLWQ==
   dependencies:
     "@idena/vrf-js" "^1.0.1"
     archiver "^5.3.0"


### PR DESCRIPTION
Update `warp-contracts` to `1.3.3-beta.3`. Fixes internal imports on Warp SDK's end