### PR TITLE
Fix versioning and remove linting from GH actions

### DIFF
--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -20,6 +20,3 @@ jobs:
 
       - name: Format Code
         run: yarn format
-
-      - name: Lint Code
-        run: lint

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "permawebjs",
-  "version": "1.2.5",
+  "version": "1.2.7",
   "description": "Utility library to build full stack permaweb applications",
   "type": "module",
   "main": "./dist/cjs/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ export {
   postTransaction,
   getTransaction,
   getTransactionStatus,
-  createAndPostTransactionWOthent
+  createAndPostTransactionWOthent,
 } from './lib/transaction';
 export {
   createContract,

--- a/src/lib/contract.ts
+++ b/src/lib/contract.ts
@@ -77,7 +77,7 @@ export async function writeContract(params: Types.WriteContractProps) {
   const contract = warp.contract(params.contractTxId).connect(params.wallet);
 
   const writeContract = await contract.writeInteraction(params.options, {
-    tags: [{ name: 'PermawebJS', value: '1.2.5' }],
+    tags: [{ name: 'PermawebJS', value: '1.2.7' }],
   });
 
   const readState = await contract.readState();
@@ -158,7 +158,7 @@ export async function writeContractWOthent(params: Types.WriteContractWOthentPro
   const signedTransaction = await othent.signTransactionWarp({
     othentFunction: params.othentFunction,
     data: params.data,
-    tags: [{ name: 'PermawebJS', value: '1.2.5' }],
+    tags: [{ name: 'PermawebJS', value: '1.2.7' }],
   });
 
   const postedTransaction = await othent.sendTransactionWarp(signedTransaction);

--- a/src/lib/transaction.ts
+++ b/src/lib/transaction.ts
@@ -27,7 +27,7 @@ export async function createTransaction<T extends Types.CreateWalletTransactionP
       const allTags = params?.options.tags && [
         {
           name: 'PermawebJS',
-          value: '1.2.5',
+          value: '1.2.7',
         },
         ...params?.options.tags,
       ];
@@ -35,7 +35,7 @@ export async function createTransaction<T extends Types.CreateWalletTransactionP
       const transaction = bundlr.createTransaction(
         JSON.stringify(params?.data),
         {
-          tags: allTags ? allTags : [{ name: 'PermawebJS', value: '1.2.5' }],
+          tags: allTags ? allTags : [{ name: 'PermawebJS', value: '1.2.7' }],
         }
       );
 
@@ -70,7 +70,7 @@ export async function createTransaction<T extends Types.CreateWalletTransactionP
       );
 
       // tags
-      transaction.addTag('PermawebJS', '1.2.5');
+      transaction.addTag('PermawebJS', '1.2.7');
       if (params?.options?.tags) {
         params?.options?.tags?.map((k, i) =>
           transaction.addTag(k.name, k.value)
@@ -113,7 +113,7 @@ export async function createTransaction<T extends Types.CreateWalletTransactionP
       );
 
       // add tags
-      transaction.addTag('PermawebJS', '1.2.5');
+      transaction.addTag('PermawebJS', '1.2.7');
       if (params?.options?.tags) {
         params?.options?.tags?.map((k, i) =>
           transaction.addTag(k.name, k.value)
@@ -240,7 +240,7 @@ export async function createAndPostTransactionWOthent(params: Types.CreateandPos
   const allTags = params?.tags && [
     {
       name: 'PermawebJS',
-      value: '1.2.5',
+      value: '1.2.7',
     },
     ...params?.tags,
   ];
@@ -251,7 +251,7 @@ export async function createAndPostTransactionWOthent(params: Types.CreateandPos
     const signedTransaction = await othent.signTransactionBundlr({
       othentFunction: params.othentFunction,
       data: params.data,
-      tags: allTags ? allTags : [{ name: 'PermawebJS', value: '1.2.5' }],
+      tags: allTags ? allTags : [{ name: 'PermawebJS', value: '1.2.7' }],
     });
 
     postedTransaction = await othent.sendTransactionBundlr(signedTransaction);
@@ -259,7 +259,7 @@ export async function createAndPostTransactionWOthent(params: Types.CreateandPos
     const signedTransaction = await othent.signTransactionArweave({
       othentFunction: params.othentFunction,
       data: params.data,
-      tags: allTags ? allTags : [{ name: 'PermawebJS', value: '1.2.5' }],
+      tags: allTags ? allTags : [{ name: 'PermawebJS', value: '1.2.7' }],
     });
 
     postedTransaction = await othent.sendTransactionArweave(signedTransaction);


### PR DESCRIPTION
It was discovered that `permawebjs` version `1.2.5 === 1.2.6`. Updating past this with the new `1.2.7` version. I also removed the line that was breaking the formatting action.